### PR TITLE
Fix Travis failed when forking the repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,10 @@ install:
   - go get -u github.com/golang/lint/golint
   - sudo -E apt-get install -y --force-yes slapd time ldap-utils
   - sudo /etc/init.d/slapd stop
-
+  - mkdir -p $HOME/gopath/src/github.com/coreos
+  - cd $HOME/gopath/src/github.com/coreos
+  - mv $HOME/gopath/src/github.com/$TRAVIS_REPO_SLUG .
+  - cd $HOME/gopath/src/github.com/coreos/dex
 
 script:
   - make testall


### PR DESCRIPTION
Travis fails because it clones de repo under the path $HOME/gopath/src/github.com/<username>/dex when it should be $HOME/gopath/src/github.com/coreos/dex